### PR TITLE
Make Image Zoom work with Starlight Blog

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -4,6 +4,7 @@ import starlight from "@astrojs/starlight";
 import solidJs from "@astrojs/solid-js";
 
 import starlightBlog from "starlight-blog";
+import starlightImageZoom from "starlight-image-zoom";
 
 // https://astro.build/config
 export default defineConfig({
@@ -22,6 +23,7 @@ export default defineConfig({
   integrations: [
     starlight({
       plugins: [
+        starlightImageZoom(),
         starlightBlog({
           authors: {
             deminearchiver: {
@@ -71,7 +73,10 @@ export default defineConfig({
         "./src/styles/custom.css",
         "./src/styles/theme.css",
         "./src/styles/landing.css",
-      ]
+      ],
+      components: {
+          MarkdownContent: "./src/components/MarkdownContent.astro",
+      },
     }),
     solidJs(),
   ]

--- a/apps/docs/src/components/MarkdownContent.astro
+++ b/apps/docs/src/components/MarkdownContent.astro
@@ -1,0 +1,8 @@
+---
+import type { Props } from '@astrojs/starlight/props'
+import Default from "starlight-blog/overrides/MarkdownContent.astro"
+import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro'
+---
+
+<ImageZoom />
+<Default {...Astro.props}><slot /></Default>


### PR DESCRIPTION
Hello!

I see that your `package.json` includes the Starlight Image Zoom, but it isn't used in your docs page.
Therefore I created this PR, which updates your code so that it uses the Image Zoom and it now works together with the Starlight Blog plugin.

I hope this helps!

Have a nice day, bye!